### PR TITLE
Improve layout when for a lot of tracked users

### DIFF
--- a/src/components/StreakView/StreakView.module.less
+++ b/src/components/StreakView/StreakView.module.less
@@ -31,16 +31,9 @@
 
   .streak-grid {
     grid-area: content;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     gap: 1rem;
-
-    & > * {
-      flex: 1;
-      max-width: var(--streak-grid-item-max-width);
-    }
   }
 
   .pointer {


### PR DESCRIPTION
Update the layout of the streak grid to use CSS Grid for even distribution of users between rows.

* Change the `.streak-grid` class in `src/components/StreakView/StreakView.module.less` to use CSS Grid layout instead of flexbox.
* Set `display` to `grid` and `grid-template-columns` to `repeat(auto-fill, minmax(200px, 1fr))`.
* Set `gap` to `1rem` to maintain spacing between grid items.
* Remove the `flex-wrap` and `justify-content` styles from the `StreakGrid` component.

