### PR TITLE
Improve layout when for a lot of tracked users

### DIFF
--- a/src/components/StreakView/StreakView.module.less
+++ b/src/components/StreakView/StreakView.module.less
@@ -31,14 +31,13 @@
 
   .streak-grid {
     grid-area: content;
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     justify-content: center;
     align-items: center;
     gap: 1rem;
 
     & > * {
-      flex: 1;
       max-width: var(--streak-grid-item-max-width);
     }
   }

--- a/src/components/StreakView/StreakView.tsx
+++ b/src/components/StreakView/StreakView.tsx
@@ -3,9 +3,26 @@ import { Typography } from "@mui/material";
 import { useConfiguration } from "../../hooks/useConfiguration";
 import styles from "./StreakView.module.less";
 import { User } from "./User/User";
+import { useEffect, useState } from "react";
 
 export const StreakView = () => {
   const { config } = useConfiguration();
+  const [numColumns, setNumColumns] = useState(1);
+
+  useEffect(() => {
+    const calculateColumns = () => {
+      const numUsers = config.userNames.length;
+      const columns = Math.ceil(Math.sqrt(numUsers));
+      setNumColumns(columns);
+    };
+
+    calculateColumns();
+    window.addEventListener("resize", calculateColumns);
+
+    return () => {
+      window.removeEventListener("resize", calculateColumns);
+    };
+  }, [config.userNames]);
 
   const Header = () => {
     return (
@@ -17,7 +34,10 @@ export const StreakView = () => {
 
   const StreakGrid = () => {
     return (
-      <div className={styles.streakGrid}>
+      <div
+        className={styles.streakGrid}
+        style={{ gridTemplateColumns: `repeat(${numColumns}, 1fr)` }}
+      >
         {config.userNames.map((userName) => (
           <User userName={userName} key={userName} />
         ))}


### PR DESCRIPTION
Fixes #63

Update the layout to distribute tracked users evenly between rows when the list needs to be wrapped.

* Change `src/components/StreakView/StreakView.module.less` to use `display: grid` and `grid-template-columns` in the `.streak-grid` class.
* Modify `src/components/StreakView/StreakView.tsx` to calculate the number of columns based on the number of users and set the `grid-template-columns` property accordingly.
* Add a new state variable `numColumns` and use `useEffect` to update it based on the number of users and window resize events.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tristanhollman/duolingo-streak-checker/pull/66?shareId=e874df22-f1b4-4c57-be43-7732b9986d55).